### PR TITLE
Use async/await for Meteor 3 compatability

### DIFF
--- a/package.js
+++ b/package.js
@@ -11,6 +11,7 @@ Package.onUse(function(api) {
 
   api.use([
     'ecmascript',
+    'babel-compiler',
     'shell-server@0.2.1',
   ], 'server');
 

--- a/package.js
+++ b/package.js
@@ -11,7 +11,7 @@ Package.onUse(function(api) {
 
   api.use([
     'ecmascript',
-    'babel-compiler',
+    'babel-compiler@7.11.0',
     'shell-server@0.2.1',
   ], 'server');
 

--- a/server/shell_server.js
+++ b/server/shell_server.js
@@ -8,7 +8,7 @@ let MeteorShell = {
     return this;
   },
 
-  ensureShellServer() {
+  async ensureShellServer() {
     try {
       if (process.env.METEOR_SHELL_DIR) {
         this.shellDir = process.env.METEOR_SHELL_DIR;
@@ -18,7 +18,7 @@ let MeteorShell = {
         this.listen(this.shellDir);
       }
 
-      this.createShellClient();
+      await this.createShellClient();
     }
     catch(e) {
       console.error('qualia:prod-shell - Failed to start Meteor shell.', e.stack || e);
@@ -73,8 +73,8 @@ let MeteorShell = {
     );
   },
 
-  createShellClient() {
-    let shellClientFile = Assets.getText('server/shell_client.js');
+  async createShellClient() {
+    let shellClientFile = await Assets.getTextAsync('server/shell_client.js');
     shellClientFile = `process.env.METEOR_SHELL_DIR = '${this.shellDir}';\n\n` + shellClientFile;
     shellClientFile = this.transpile(shellClientFile);
 
@@ -83,7 +83,7 @@ let MeteorShell = {
 
   transpile(code) {
     process.env.BABEL_CACHE_DIR = process.env.BABEL_CACHE_DIR || process.cwd();
-    return Package.ecmascript.ECMAScript.compileForShell(code);
+    return Babel.compileForShell(code);
   },
 
 }.initialize();


### PR DESCRIPTION
This updates the package to use async/await so that the package can be used in a Meteor 3 app.